### PR TITLE
Test PR for Bintray automated build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: "Test: Extract PR and Git info from env"
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]]; then
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]] then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
               PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,16 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
+          name: "Test: Extract PR and Git info from env"
+          command: |
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+            fi
+
+            echo "Prefix is $PREFIX"
+
+      - run:
           name: Experimental Bintray Upload
           command: |
             # Locally, calling `./gradlew bintrayUpload` is enough to generate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,11 @@ jobs:
       - run:
           name: Experimental Bintray Upload
           command: |
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+            fi
+
             # Locally, calling `./gradlew bintrayUpload` is enough to generate
             # all the required artifacts. On CI, unless run each task
             # individually, the Bintray task will fail to find the .aar and
@@ -78,7 +83,11 @@ jobs:
             # See also the description and comments in this PR:
             # https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/39
             ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication
-            ./gradlew --stacktrace bintrayUpload
+
+            # If $PREFIX is not set, that is, if we're not on a PR but a merge
+            # commit on develop or trunk, the plugin will fallback to reading
+            # the version value from the source code.
+            ./gradlew --stacktrace bintrayUpload -PbintrayVersion=$PREFIX
       - android/save-gradle-cache
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: "Test: Extract PR and Git info from env"
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1"]] then
+            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
               PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,18 @@ jobs:
       - run:
           name: Experimental Bintray Upload
           command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
+            branch=$CIRCLE_BRANCH
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+              if [[ -n "$CIRCLE_PULL_REQUEST" && -n "$CIRCLE_SHA1" ]]; then
               PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
               PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+              fi
+            # Checking on master as well for retro-compatibility.
+            # Once all of the projects have migrated to trunk, we shall remove
+            # that check.
+            elif [[ "$branch" != "trunk" || "$branch" != "develop" || "$branch" != "master" ]]; then
+              echo "Running on a feature branch with no open PR: skipping Bintray upload"
+              exit 0
             fi
 
             # Locally, calling `./gradlew bintrayUpload` is enough to generate

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # WordPress-Utils-Android
 
+
 Collection of utility methods for Android and WordPress.
 
 ## Use the library in your project

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -106,6 +106,10 @@ def getCheckedOutGitCommitHash() {
 }
 
 def getBintrayVersion() {
+  project.properties['bintrayVersion'] ?: getBintrayVersion_()
+}
+
+def getBintrayVersion_() {
   // One option could be to use "branch-sha" as the version
   // return "${getGitBranch()}-${getCheckedOutGitCommitHash()}"
 


### PR DESCRIPTION
Once this is opened, I expect a new CI task that uploads the build to Bintray with version: `PR_id-sha1`

Once this is merged, I expect a CI task from `develop` with the version from the codebase.