### PR TITLE
PR to demo autopublishing when merging to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Test
           command: ./gradlew --stacktrace test
       - android/save-gradle-cache
-  Build:
+  Build and upload to Bintray:
     executor:
       name: android/default
       api-version: "27"
@@ -45,15 +45,67 @@ jobs:
       - copy-gradle-properties
       - android/restore-gradle-cache
       - run:
-          name: Build
-          command: ./gradlew --stacktrace assembleDebug assembleRelease
+          name: Bintray Upload
+          command: |
+            # Use a different versioning style for builds from PRs to allow
+            # developers to iterate faster.
+            #
+            # All those dev builds will be deleted once the PR is merged by
+            # https://github.com/Automattic/bintray-garbage-collector/
+            #
+            # If $PREFIX is not set, that is, if we're not on a PR but a merge
+            # commit on develop or trunk, the version will be the value from
+            # the source code.
+            branch=$CIRCLE_BRANCH
+            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
+              # Making the assumption that $CIRCLE_SHA1 will always be
+              # available.
+              PREFIX="$PR_NUMBER-$CIRCLE_SHA1"
+            elif [[ "$branch" != "trunk" && "$branch" != "develop" ]]; then
+              # This happens on the first push of a new branch, when there
+              # isn't a PR open for it yet.
+              echo "Running on a feature branch with no open PR: skipping Bintray upload"
+              exit 0
+            fi
+
+            # Locally, calling `./gradlew bintrayUpload` is enough to generate
+            # all the required artifacts. On CI, unless run each task
+            # individually, the Bintray task will fail to find the AAR and
+            # POM artifacts in the build/ folder.
+            #
+            # This builds the AAR.
+            ./gradlew --stacktrace assembleRelease
+
+            # This builds the POM.
+            #
+            # On local, the POM is generated automatically as part of
+            # assembleRelease, but that doesn't seem to be the case on CI. Here
+            # we need to explicitly generated it, otherwise bintrayUpload won't
+            # find it and won't upload it.
+            #
+            # Worth noting that the Bintray plugin mentions the necessity for
+            # a workaround to generate the POM. See:
+            # https://github.com/bintray/gradle-bintray-plugin#maven-publications
+            #
+            # See also the description and comments in this PR:
+            # https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/39
+            #
+            # Notice the `-PbintrayVersion` parameter to make sure the POM has
+            # the same version as the one bintrayUpload will use.
+            ./gradlew --stacktrace generatePomFileForUtilsPublicationPublication -PbintrayVersion=$PREFIX
+
+            # Finally, this uploads both AAR and POM to Bintray.
+            ./gradlew --stacktrace bintrayUpload -PbintrayVersion=$PREFIX
       - android/save-gradle-cache
 
 workflows:
+  # We don't want this to run on tags, but no filter statement is necessary
+  # because that's the default behavior
   WordPress-Utils-Android:
     jobs:
       - Lint
       - Test
-      - Build:
+      - Build and upload to Bintray:
           requires:
             - Test

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -107,11 +107,17 @@ bintray {
     }
 }
 
+// Because the components are created only during the `afterEvaluate` phase, we
+// must configure our publications using the `afterEvaluate()` lifecycle method
+//
+// See https://developer.android.com/studio/build/maven-publish-plugin
 project.afterEvaluate {
     publishing {
         publications {
             UtilsPublication(MavenPublication) {
+                // Applies the component for the release build variant
                 from components.release
+
                 groupId 'org.wordpress'
                 artifactId 'utils'
                 version android.defaultConfig.versionName

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -88,6 +88,12 @@ android.libraryVariants.all { variant ->
     }
 }
 
+// Allows to override the artifact version by passing a -PbintrayVersion
+// parameter when calling Gradle
+def getBintrayVersion() {
+  return project.properties['bintrayVersion'] ?: android.defaultConfig.versionName
+}
+
 bintray {
     user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
     key = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_KEY')
@@ -100,7 +106,7 @@ bintray {
         licenses = ['MIT', 'GPL']
         vcsUrl = 'https://github.com/wordpress-mobile/WordPress-Utils-Android.git'
         version {
-            name = android.defaultConfig.versionName
+            name = getBintrayVersion()
             desc = 'Utils library for Android'
             released  = new Date()
         }
@@ -120,7 +126,7 @@ project.afterEvaluate {
 
                 groupId 'org.wordpress'
                 artifactId 'utils'
-                version android.defaultConfig.versionName
+                version getBintrayVersion()
             }
         }
     }

--- a/WordPressUtils/build.gradle
+++ b/WordPressUtils/build.gradle
@@ -101,8 +101,8 @@ bintray {
     publish = true
     pkg {
         repo = 'maven'
-        name = 'utils'
-        userOrg = 'wordpress-mobile'
+        name = 'utils-experiment'
+        userOrg = 'mokagio'
         licenses = ['MIT', 'GPL']
         vcsUrl = 'https://github.com/wordpress-mobile/WordPress-Utils-Android.git'
         version {


### PR DESCRIPTION
Notice that I changed the Bintray repository to my fork, just so we don't pollute the official one.

---

Here's the build published form this branch. The [garbage collector](https://github.com/Automattic/bintray-garbage-collector/) will delete it within 24h from this being merged.

![image](https://user-images.githubusercontent.com/1218433/99474790-5d7eda00-29a1-11eb-9fbf-4994280110cf.png)

---

[Here](https://bintray.com/beta/#/mokagio/maven/utils-experiment/1.30?tab=overview)'s the build published when this PR was merged on `develop` by [this CI build](https://app.circleci.com/pipelines/github/mokagio/WordPress-Utils-Android/33/workflows/2bea653c-30f2-4391-91b5-331e3b4e7477/jobs/48)

![image](https://user-images.githubusercontent.com/1218433/99475379-85bb0880-29a2-11eb-936b-e38df8a380d8.png)
